### PR TITLE
updated tifffile.imsave to save in imagej False/bigtiff True format

### DIFF
--- a/mesmerize/viewer/modules/batch_run_modules/caiman_motion_correction.py
+++ b/mesmerize/viewer/modules/batch_run_modules/caiman_motion_correction.py
@@ -125,7 +125,7 @@ def run_single(batch_dir, UUID, output):
         m_els = m_els.astype(np.uint16)
 
     img_out_path = os.path.join(batch_dir, f'{UUID}_mc.tiff')
-    tifffile.imsave(img_out_path, m_els, bigtiff=True, imagej=True, compress=1)
+    tifffile.imsave(img_out_path, m_els, bigtiff=True, imagej=False, compress=1)
     output['output_files'] = [UUID + '_mc.tiff']
 
     output.update({'status': 1, 'bord_px': int(bord_px_els)})
@@ -215,7 +215,7 @@ def run_multi(batch_dir, UUID, output):
         mc_out[:, z, :, :] = m_els
 
     img_out_path = os.path.join(batch_dir, f'{UUID}_mc.tiff')
-    tifffile.imsave(img_out_path, mc_out, bigtiff=True, imagej=True, compress=1)
+    tifffile.imsave(img_out_path, mc_out, bigtiff=True, imagej=False, compress=1)
     output['output_files'] = [f'{UUID}_mc.tiff']
 
     output.update(


### PR DESCRIPTION
Within `batch_run_modules`, change the tiff save operation to save the files in different format, with parameters `bigtiff=True` and `imagej=False` instead of current parameters `bigtiff=True` and `imagej=True`. 

This change removes the warning thrown by `tifffile`, allows files to be opened by Inscopix software (currently they throw an error), and with this change the files can still be opened by other software such as `imagej`.

I have tested MESmerize with multiple runs through motion correction, CNMFE on Windows with no problems. Have not tested on Linux/mac. 