### PR TITLE
fixed ptime issue for Python 3.8

### DIFF
--- a/mesmerize/pyqtgraphCore/ptime.py
+++ b/mesmerize/pyqtgraphCore/ptime.py
@@ -13,7 +13,7 @@ time = None
 
 def winTime():
     """Return the current time in seconds with high precision (windows version, use Manager.time() to stay platform independent)."""
-    return systime.clock() + START_TIME
+    return systime.process_time() + START_TIME
     #return systime.time()
 
 def unixTime():
@@ -21,10 +21,9 @@ def unixTime():
     return systime.time()
 
 if sys.platform.startswith('win'):
-    cstart = systime.clock()  ### Required to start the clock in windows
+    cstart = systime.process_time()  ### Required to start the clock in windows
     START_TIME = systime.time() - cstart
-    
+
     time = winTime
 else:
     time = unixTime
-


### PR DESCRIPTION
This should fix compatability problems between pyqtgraph-core and Python 3.8. This issue is discussed here:
https://github.com/conda-forge/pyqtgraph-feedstock/issues/10

Basically, replace two instances of `systime.clock` with `systime.process_time` and the errors go away when installing with Python 3.8.