### PR TITLE
updated ui and compiled template file for cnmfe gui

### DIFF
--- a/mesmerize/viewer/modules/pytemplates/cnmfe_pytemplate.py
+++ b/mesmerize/viewer/modules/pytemplates/cnmfe_pytemplate.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file './ui_files/cnmfe_pytemplate.ui'
+# Form implementation generated from reading ui file 'ui_files/cnmfe_pytemplate.ui'
 #
-# Created by: PyQt5 UI code generator 5.12.3
+# Created by: PyQt5 UI code generator 5.12
 #
 # WARNING! All changes made in this file will be lost!
-
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -124,11 +123,11 @@ class Ui_DockWidget(object):
         self.label_10 = QtWidgets.QLabel(self.dockWidgetContents)
         self.label_10.setObjectName("label_10")
         self.horizontalLayout_7.addWidget(self.label_10)
-        self.spinBoxMinPNR = QtWidgets.QSpinBox(self.dockWidgetContents)
-        self.spinBoxMinPNR.setMaximum(999)
-        self.spinBoxMinPNR.setProperty("value", 4)
-        self.spinBoxMinPNR.setObjectName("spinBoxMinPNR")
-        self.horizontalLayout_7.addWidget(self.spinBoxMinPNR)
+        self.doubleSpinBoxMinPNR = QtWidgets.QDoubleSpinBox(self.dockWidgetContents)
+        self.doubleSpinBoxMinPNR.setSingleStep(0.05)
+        self.doubleSpinBoxMinPNR.setProperty("value", 2.0)
+        self.doubleSpinBoxMinPNR.setObjectName("doubleSpinBoxMinPNR")
+        self.horizontalLayout_7.addWidget(self.doubleSpinBoxMinPNR)
         spacerItem3 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout_7.addItem(spacerItem3)
         self.verticalLayout_2.addLayout(self.horizontalLayout_7)
@@ -314,10 +313,11 @@ class Ui_DockWidget(object):
         self.label_12 = QtWidgets.QLabel(self.dockWidgetContents)
         self.label_12.setObjectName("label_12")
         self.horizontalLayout_8.addWidget(self.label_12)
-        self.spinBoxMinSNR = QtWidgets.QSpinBox(self.dockWidgetContents)
-        self.spinBoxMinSNR.setProperty("value", 1)
-        self.spinBoxMinSNR.setObjectName("spinBoxMinSNR")
-        self.horizontalLayout_8.addWidget(self.spinBoxMinSNR)
+        self.doubleSpinBoxMinSNR = QtWidgets.QDoubleSpinBox(self.dockWidgetContents)
+        self.doubleSpinBoxMinSNR.setSingleStep(0.1)
+        self.doubleSpinBoxMinSNR.setProperty("value", 1.0)
+        self.doubleSpinBoxMinSNR.setObjectName("doubleSpinBoxMinSNR")
+        self.horizontalLayout_8.addWidget(self.doubleSpinBoxMinSNR)
         spacerItem13 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout_8.addItem(spacerItem13)
         self.verticalLayout.addLayout(self.horizontalLayout_8)
@@ -395,8 +395,8 @@ class Ui_DockWidget(object):
         DockWidget.setTabOrder(self.btnAddToBatchCorrPNR, self.lineEditAin)
         DockWidget.setTabOrder(self.lineEditAin, self.spinBox_p)
         DockWidget.setTabOrder(self.spinBox_p, self.doubleSpinBoxMinCorr)
-        DockWidget.setTabOrder(self.doubleSpinBoxMinCorr, self.spinBoxMinPNR)
-        DockWidget.setTabOrder(self.spinBoxMinPNR, self.spinBoxRf)
+        DockWidget.setTabOrder(self.doubleSpinBoxMinCorr, self.doubleSpinBoxMinPNR)
+        DockWidget.setTabOrder(self.doubleSpinBoxMinPNR, self.spinBoxRf)
         DockWidget.setTabOrder(self.spinBoxRf, self.spinBoxOverlap)
         DockWidget.setTabOrder(self.spinBoxOverlap, self.spinBoxGnb)
         DockWidget.setTabOrder(self.spinBoxGnb, self.spinBoxNb_patch)
@@ -409,8 +409,8 @@ class Ui_DockWidget(object):
         DockWidget.setTabOrder(self.comboBoxDeconv, self.doubleSpinBoxMergeThresh)
         DockWidget.setTabOrder(self.doubleSpinBoxMergeThresh, self.groupBox_cnmf_kwargs)
         DockWidget.setTabOrder(self.groupBox_cnmf_kwargs, self.plainTextEdit_cnmf_kwargs)
-        DockWidget.setTabOrder(self.plainTextEdit_cnmf_kwargs, self.spinBoxMinSNR)
-        DockWidget.setTabOrder(self.spinBoxMinSNR, self.doubleSpinBoxRValuesMin)
+        DockWidget.setTabOrder(self.plainTextEdit_cnmf_kwargs, self.doubleSpinBoxMinSNR)
+        DockWidget.setTabOrder(self.doubleSpinBoxMinSNR, self.doubleSpinBoxRValuesMin)
         DockWidget.setTabOrder(self.doubleSpinBoxRValuesMin, self.doubleSpinBoxDecayTime)
         DockWidget.setTabOrder(self.doubleSpinBoxDecayTime, self.groupBox_eval_kwargs)
         DockWidget.setTabOrder(self.groupBox_eval_kwargs, self.plainTextEdit_eval_kwargs)
@@ -470,10 +470,12 @@ class Ui_DockWidget(object):
         self.label_16.setText(_translate("DockWidget", "decay_time:"))
         self.groupBox_eval_kwargs.setToolTip(_translate("DockWidget", "You can enter additional parameters to use for component evaluation.\n"
 "Use single quotes for strings, do not use double quotes"))
-        self.groupBox_eval_kwargs.setTitle(_translate("DockWidget", "Use e&valuation params"))
+        self.groupBox_eval_kwargs.setTitle(_translate("DockWidget", "Use e&valuation kwargs"))
         self.plainTextEdit_eval_kwargs.setToolTip(_translate("DockWidget", "You can enter additional parameters to use for component evaluation.\n"
 "Use single quotes for strings, do not use double quotes"))
         self.checkBoxKeepMemmap.setText(_translate("DockWidget", "Keep memmap"))
         self.label_18.setText(_translate("DockWidget", "Perform CNMF-E:"))
         self.lineEdName.setPlaceholderText(_translate("DockWidget", "Enter name"))
         self.btnAddToBatchCNMFE.setText(_translate("DockWidget", "Add to batch"))
+
+

--- a/mesmerize/viewer/modules/ui_files/cnmfe_pytemplate.ui
+++ b/mesmerize/viewer/modules/ui_files/cnmfe_pytemplate.ui
@@ -249,12 +249,12 @@
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBoxMinPNR">
-          <property name="maximum">
-           <number>999</number>
+         <widget class="QDoubleSpinBox" name="doubleSpinBoxMinPNR">
+          <property name="singleStep">
+           <double>0.050000000000000</double>
           </property>
           <property name="value">
-           <number>4</number>
+           <double>2.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -728,9 +728,12 @@ Use single quotes for strings, do not use double quotes.</string>
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="spinBoxMinSNR">
+         <widget class="QDoubleSpinBox" name="doubleSpinBoxMinSNR">
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
           <property name="value">
-           <number>1</number>
+           <double>1.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -845,7 +848,7 @@ If lower more components will be accepted, potentially with worse quality</strin
 Use single quotes for strings, do not use double quotes</string>
         </property>
         <property name="title">
-         <string>Use e&amp;valuation params</string>
+         <string>Use e&amp;valuation kwargs</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
@@ -915,7 +918,7 @@ Use single quotes for strings, do not use double quotes</string>
   <tabstop>lineEditAin</tabstop>
   <tabstop>spinBox_p</tabstop>
   <tabstop>doubleSpinBoxMinCorr</tabstop>
-  <tabstop>spinBoxMinPNR</tabstop>
+  <tabstop>doubleSpinBoxMinPNR</tabstop>
   <tabstop>spinBoxRf</tabstop>
   <tabstop>spinBoxOverlap</tabstop>
   <tabstop>spinBoxGnb</tabstop>
@@ -929,7 +932,7 @@ Use single quotes for strings, do not use double quotes</string>
   <tabstop>doubleSpinBoxMergeThresh</tabstop>
   <tabstop>groupBox_cnmf_kwargs</tabstop>
   <tabstop>plainTextEdit_cnmf_kwargs</tabstop>
-  <tabstop>spinBoxMinSNR</tabstop>
+  <tabstop>doubleSpinBoxMinSNR</tabstop>
   <tabstop>doubleSpinBoxRValuesMin</tabstop>
   <tabstop>doubleSpinBoxDecayTime</tabstop>
   <tabstop>groupBox_eval_kwargs</tabstop>


### PR DESCRIPTION
Minor tweaks to cnmfe ui:
- minPNR and minSNR converted from `int` to `float`.
-  Text for box to use `eval kwargs` changed to `Use eval kwargs` instead of `Use eval params`.

Diff looks reasonable no surprising changes.  Have tested in Windows 10.